### PR TITLE
getAOI testing

### DIFF
--- a/R/getAOI.R
+++ b/R/getAOI.R
@@ -78,34 +78,26 @@ getAOI = function(state = NULL,
   #------------------------------------------------------------------------------#
   # Error Catching                                                               #
   #------------------------------------------------------------------------------#
-  if (!is.null(state) && !is.null(clip_unit)) {
-    stop("Only 'state' or 'clip_unit' can be used. Set the other to NULL")
+  if (!is.null(state)) {
+    if (!is.null(clip_unit)) {
+      stop("Only 'state' or 'clip_unit' can be used. Set the other to NULL")
+    }
+    for (value in state) {
+      if (!is.character(value)) {
+        stop("State must be a character value. Try surrounding in qoutes...")
+      }
+      if (!(toupper(value) %in% datasets::state.abb || tolower(value) %in% tolower(datasets::state.name))) {
+        stop("State not recongized. Full names or abbreviations can be used. Please check spelling.")
+      }
+    }
   }
-
-  if (is.null(state) &&
-      is.null(clip_unit) && !is.null(county)) {
-    stop("The use of 'county' requires the 'state' parameter be used as well.")
-  }
-
-  if (is.null(state) && is.null(clip_unit)) {
-    stop("Requires a 'clip_unit' or 'state' parameter to execute")
-  }
-
-  if (!is.null(clip_unit) &&
-      (!is.null(state) || !is.null(county))) {
-    stop("If providing 'clip_unit', leave 'state' and 'county' as 'NULL'")
-  }
-
-  if (!is.null(state) && !is.character(state)) {
-    stop("State must be a character value. Try surrounding in qoutes...")
-  }
-
-  if (!is.null(state) &&
-      !(toupper(state) %in% datasets::state.abb ||
-        state %in% datasets::state.name)) {
-    stop(
-      "State not recongized. Full names or abbreviations can be used. Please check spelling."
-    )
+  else {
+    if (!is.null(county)) {
+      stop("The use of 'county' requires the 'state' parameter be used as well.")
+    }
+    if (is.null(clip_unit)) {
+      stop("Requires a 'clip_unit' or 'state' parameter to execute")
+    }
   }
 
   #-----------------------------------------------------------------------------------#

--- a/R/getFiatBoundary.R
+++ b/R/getFiatBoundary.R
@@ -45,6 +45,20 @@
 
 getFiatBoundary <- function(state = NULL, county = NULL, clip_unit = NULL) {
 
+  USAboundaries_version <- "0.3.1"
+
+  install_USAboundariesData <- function() {
+    install.packages("USAboundariesData", repos = "http://packages.ropensci.org", type = "source")
+  }
+
+  if (!requireNamespace("USAboundariesData", quietly = TRUE)) {
+    message("Installing USAboundariesData package.")
+    install_USAboundariesData()
+  } else if (utils::packageVersion("USAboundariesData") < USAboundaries_version) {
+    message("Updating the USAboundariesData package.")
+    install_USAboundariesData()
+  }
+
   if(!is.null(clip_unit)){
     A = getAOI(state = NULL, county = NULL, clip_unit = clip_unit)
 

--- a/tests/testthat/test_getAOI.R
+++ b/tests/testthat/test_getAOI.R
@@ -1,0 +1,21 @@
+context("getAOI")
+
+state_only <- getAOI(state = "Colorado")
+multiple_states <- getAOI(state = c('CA', 'nevada'))
+state_county <- getAOI(state = 'California', county = c('Santa Barbara', 'ventura'))
+clip_1 <- getAOI(clip_unit = list('KMART near UCSB', 10, 10, 'lowerleft'))
+
+test_that("getAOI throws correct errors", {
+  expect_error(getAOI(state = '23'), "State not recongized. Full names or abbreviations can be used. Please check spelling.")
+  expect_error(getAOI(state= c('CA', 23)), "State not recongized. Full names or abbreviations can be used. Please check spelling.")
+  expect_error(getAOI(state = 'CA', clip_unit = list('KMART near UCSB', 10, 10)), "Only 'state' or 'clip_unit' can be used. Set the other to NULL")
+  expect_error(getAOI(county = 'Santa Barbara'), "The use of 'county' requires the 'state' parameter be used as well.")
+  expect_error(getAOI(), "Requires a 'clip_unit' or 'state' parameter to execute")
+})
+
+test_that("AOI returns type 'S4'", {
+  expect_equal(typeof(state_only), "S4")
+  expect_equal(typeof(state_county), "S4")
+  expect_equal(typeof(clip_1), "S4")
+})
+


### PR DESCRIPTION
- Changes to `getAOI.R`:

    * Code optimization - at most, checks value of `is.null(parem)` once for each parameter

    * Check validity of all values in a state arrray.  e.g. `getAOI(state= c('CA', 23))`  will now throw an error

- Changes to `getFiatBoundary.R`

    * Downloads USAboundariesData if needed.  Missing package was resulting in the following error:

```
Running the tests in ‘tests/testthat.R’ failed.
Last 13 lines of output:
    Please try installing the package for yourself using the following command: 
       install.packages("USAboundariesData", repos = "http://packages.ropensci.org", type = "source")
  1: getAOI(state = "Colorado") at testthat/test_getAOI.R:3
  2: getFiatBoundary(state = state, county = county)
  3: USAboundaries::us_counties(map_date = NULL, resolution = "high", states = state)
  4: check_data_package()
  5: install_data_package()
  6: stop(paste("Failed to install the USAboundariesData package.\n", instructions))
```

- Some initial tests for the `getAOI` function
