### PR TITLE
findwbd_staged is not exported

### DIFF
--- a/R/findWBD.R
+++ b/R/findWBD.R
@@ -81,7 +81,7 @@ findWBD = function(AOI,
     if(is.null(shp)){
 
       cat(crayon::white("\nQuery to large for REST Service...\nReverting to direct download...\nPlease be patient...\n\n"))
-      AOI = HydroData::findWBD_staged(AOI = AOI, level = level, crop = crop)
+      AOI = HydroData:::findWBD_staged(AOI = AOI, level = level, crop = crop)
       return(report.wbd(AOI, ids = ids, crop = crop, level = level))
 
     } else {


### PR DESCRIPTION
On direct download I was getting an error similar to:

> Could not locate exported `findWBD_staged` function. 

This PR specifies that it is an un-exported function.